### PR TITLE
docs: Add release badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # SHAPER (v1.0.0)
 
+[![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/rikab/shaper)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7689890.svg)](https://doi.org/10.5281/zenodo.7689890)
+
+[![PyPI version](https://img.shields.io/pypi/v/pyshaper.svg)](https://pypi.org/project/pyshaper/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/pyshaper.svg)](https://pypi.org/project/pyshaper/)
+
 `SHAPER` is a framework for defining, building, and evaluating generalized shape observables for collider physics, as defined in ["SHAPER: Can You Hear the Shape of a Jet?" (arxiv:2302.12266)](https://arxiv.org/abs/2302.12266). This package can be used for evaluating an extremely large class of IRC-safe observables, with modules in place to define custom observables and jet algorithms using an intuitive geometric language.
 
 ![3-point-ellipsiness-plus-pileup_event_0](https://user-images.githubusercontent.com/78619093/221254441-36b3bcc4-65fc-4211-aaef-2332c5dd893e.gif)
@@ -59,8 +65,8 @@ If you use `SHAPER`, please cite both this code archive and the corresponding pa
       author = {Rikab Gambhir},
       title = "{pyshaper: v1.0.0}",
       version = {1.0.0},
-      doi = {10.5281/zenodo.7689891},
-      url = {doi.org/10.5281/zenodo.7689891,
+      doi = {10.5281/zenodo.7689890},
+      url = {doi.org/10.5281/zenodo.7689890},
       note = {https://github.com/rikab/SHAPER/releases/tag/v1.0.0}
     }
 


### PR DESCRIPTION
* Add the following badges to the README:

   - [![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/rikab/shaper): Badge that links back to the GitHub project which provides an easy way for people to find the project from the README being displayed on other sites (e.g. PyPI).
   - [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7689890.svg)](https://doi.org/10.5281/zenodo.7689890): Link to the Zenodo archive (use the "all versions" DOI).
   - [![PyPI version](https://img.shields.io/pypi/v/pyshaper.svg)](https://pypi.org/project/pyshaper/): Link to the latest release on PyPI.
   - [![Supported Python versions](https://img.shields.io/pypi/pyversions/pyshaper.svg)](https://pypi.org/project/pyshaper/): Display the versions of CPython that the latest release on PyPI is compatible with, as defined in the PyPI metadata in pyproject.toml.

* Update the Zenodo DOI information in the citation information to use the "all versions" DOI to avoid having to manually update the DOI each time a version is updated and a new DOI is created. This is safe as the "all versions" DOI will automatically resolve to the latest release DOI.