### PR TITLE
build: Update geomloss lower bound to v0.2.6 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The `SHAPER` framework contains::
 In your Python environment run
 
 ```
-python -m pip install numpy torch  # c.f. https://github.com/jeanfeydy/geomloss/issues/69
 python -m pip install pyshaper
 # python -m pip install --upgrade 'pyshaper[all]'  # for all extras
 ```
@@ -37,7 +36,6 @@ python -m pip install pyshaper
 In your Python environment from the top level of this repository run
 
 ```
-python -m pip install numpy torch  # c.f. https://github.com/jeanfeydy/geomloss/issues/69
 python -m pip install .
 # python -m pip install --upgrade '.[all]'  # for all extras
 ```
@@ -47,7 +45,6 @@ python -m pip install .
 In your Python environment run
 
 ```
-python -m pip install numpy torch  # c.f. https://github.com/jeanfeydy/geomloss/issues/69
 python -m pip install "pyshaper @ git+https://github.com/rikab/shaper.git"
 # python -m pip install --upgrade "pyshaper[all] @ git+https://github.com/rikab/shaper.git"  # for all extras
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
     "torch>=1.10.0",
-    "geomloss>=0.2.3",
+    "geomloss>=0.2.6",
     "pyjet>=1.9.0",  # FIXME: Deprecated
     "scipy>=1.5.1",
     "matplotlib>=3.5.0",


### PR DESCRIPTION
* [`geomloss` `v0.2.6`](https://github.com/jeanfeydy/geomloss/releases/tag/v0.2.6) is the first release with fixed install dependencies.
   - c.f. https://github.com/jeanfeydy/geomloss/pull/59#issuecomment-1527879868
* Remove pre-install directions of numpy and torch from the README as these are now properly handled.